### PR TITLE
Revisions: AuthPSK focus, split out `pskAPKE` from extension and treat as informative.

### DIFF
--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -312,13 +312,9 @@ Whether
 this property holds formally for a specific `CombineSecrets` variant depends on
 that variant's security analysis, which is outside the scope of this document.
 
-A quantum adversary that breaks the
-DH assumption can also forge sender authentication, so post-quantum sender
-authentication would require an additional PQ signature. Note that {{Alwen2023}}
-describes a related hybrid construction in which a PQ *AKEM* (rather than a
-plain KEM) is used to generate the PSK, which would additionally provide
-post-quantum sender authentication; that stronger construction is outside the
-scope of this document.
+**Authentication.** This mode retains the implicit sender
+authentication properties of DHAKEM described in {{?RFC9180}}.
+A quantum adversary with access to the PSK can also forge authenticated messages.
 
 **PSK freshness.** The PSK `psk` MUST satisfy the
 entropy requirement in {{Section 9.5 of !I-D.ietf-hpke-hpke}} (32 bytes of
@@ -364,29 +360,24 @@ the resulting shared secret `ss_pq` as "PSK", and a static identifier as the
 PSK identifier. The receiver's PQ public key `pkR_pq` is included in `info` to
 bind it to the key schedule.
 
-The shared secret `ss_pq` must satisfy the entropy requirement in
-{{Section 9.5 of !I-D.ietf-hpke-hpke}}.
-
-As with {{sec-hybrid}}, only classical sender authentication is provided.
-
 An example construction is provided below, with reference to the following terms:
 
 - **PQ-KEM:** a post-quantum KEM, e.g., ML-KEM {{FIPS203}} or an
   algorithm from {{?I-D.ietf-hpke-pq}}.
-- `PQKEM.Encap(pkR_pq)`: PQ-KEM encapsulation; returns `(ss_pq, enc_pq)`.
+- `PQKEM.Encap(pkR_pq)`: PQ-KEM encapsulation; returns `(enc_pq, ss_pq)`.
 - `PQKEM.Decap(enc_pq, skR_pq)`: PQ-KEM decapsulation; returns `ss_pq`.
 - `Nenc_pq`: the fixed ciphertext length of the chosen PQ-KEM, in bytes.
 
 ~~~
 def HybridSetupS(pkR, pkR_pq, skS, info):
-  ss_pq, enc_pq = PQKEM.Encap(pkR_pq)
-  enc_dh, ctx = SetupAuthPSKS(pkR, concat(info, pkR_pq), ss_pq, enc_pq, skS)
+  enc_pq, ss_pq = PQKEM.Encap(pkR_pq)
+  enc_dh, ctx = SetupAuthPSKS(pkR, concat(info, enc_pq), ss_pq, enc_pq, skS)
   return concat(enc_dh, enc_pq), ctx
 
 def HybridSetupR(enc, skR, skR_pq, pkR_pq, pkS, info):
   enc_dh, enc_pq = enc[:Nenc], enc[Nenc:]
   ss_pq = PQKEM.Decap(enc_pq, skR_pq)
-  return SetupAuthPSKR(enc_dh, skR, concat(info, pkR_pq), ss_pq, enc_pq, pkS)
+  return SetupAuthPSKR(enc_dh, skR, concat(info, enc_pq), ss_pq, enc_pq, pkS)
 ~~~
 
 Implementations should verify `len(enc) == Nenc + Nenc_pq` and reject

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -74,6 +74,7 @@ informative:
     rc: "Advances in Cryptology -- ASIACRYPT 2023"
     target: https://eprint.iacr.org/2023/1480
   I-D.draft-connolly-cfrg-xwing-kem-10:
+  I-D.draft-ietf-tls-hybrid-design-16:
   PQCodePkgs:
     title: "PQ Code Package Repositories (accessed 2026-04-30)"
     author:
@@ -94,8 +95,8 @@ The standards-track {{!I-D.ietf-hpke-hpke}} supersedes the informational
 This document restores `mode_auth_psk` mode as a strict extension, and illustrates
 how the restored mode can be used with a post-quantum shared secret as the PSK
 by application developers seeking to achieve hybrid PQ/T confidentiality while
-transitioning to quantum-safe encryption, without deprecating the implicit
-authentication properties of DHAKEM on which many applications still rely.
+transitioning to quantum-safe encryption, without deprecating the classical
+implicit authentication property on which many applications still rely.
 
 This extension requires only the
 addition of `AuthEncap()`/`AuthDecap()` to the DHKEM, the definition of four
@@ -320,9 +321,8 @@ the classical DH-based component and the PQ-KEM to recover `secret`, as seen
 in {{!I-D.ounsworth-cfrg-kem-combiners}} and subsequently,
 {{?I-D.draft-connolly-cfrg-xwing-kem-10}}.
 
-Whether
-this property holds formally for a specific `CombineSecrets` variant depends on
-that variant's security analysis, which is outside the scope of this document.
+Whether this property holds formally for a specific `CombineSecrets` variant depends
+on that variant's security analysis, which is outside the scope of this document.
 
 **Authentication.** This mode retains the implicit sender
 authentication properties of DHAKEM described in {{?RFC9180}}.
@@ -399,26 +399,33 @@ scope of this document.
 
 ## Motivation (Informative) {#sec-motivation}
 
-Downstream application developers are in a bind: though they may be aware of advice to
+Application developers are in a bind: though they may be aware of advice to
 implement quantum-safe encryption on an accelerated timeline, they may encounter rapidly-
 evolving guidance on best practices, a lack of direct parity with classical constructions,
-and a releative paucity of stable APIs suitable for non-cryptographers {{PQCodePkgs}}.
+and a relative paucity of stable libraries and APIs {{PQCodePkgs}}.
 
-Non-cryptographers looking to offer classical/quantum-safe (hybrid) encryption in their
-own applications can look to early-stage implementations of
-{{?I-D.draft-connolly-cfrg-xwing-kem-10}}, or may refer to now-expired
-{{!I-D.ounsworth-cfrg-kem-combiners}}, but will need to manage their own implementation.
-Further, the guidance on post-quantum signature schemes is still under active development,
-and if libraries are available, they come with strong caveats about changing APIs and general
-maturity.
+Developers looking to offer classical/quantum-safe (hybrid) encryption in their
+own applications, for reasons described for example in {{Section 2.1 of ?RFC9370}},
+can look to early-stage implementations of {{?I-D.draft-connolly-cfrg-xwing-kem-10}},
+or may refer to now-expired {{!I-D.ounsworth-cfrg-kem-combiners}}, but will need to
+manage their own combiner implementation.
 
-Although DH-based authentication is not future-forward, it remains in widespread use.
-Further, although the property of hybrid encryption with classical authentication is not as
-straightforward to communicate as an unauthenticated hybrid construct, protocols such as
-Noise IK, as used in {{Wireguard2020}}, indicate their usage.
-Simple APIs that allow application developers to deploy quantum-resistent encryption as
+On the other hand, production-ready quantum-safe authentication is still maturing.
+Standardized schemes offer non-repudiable, signature-based authentication, which is
+not a direct replacement for the type of DH-based implicit authentication described
+in the `auth` modes of {{?RFC9180}} or this document.
+
+Although the property of hybrid encryption with classical authentication is not as
+straightforward to communicate as unauthenticated hybrid encryption that forgoes implict
+authentication entirely, protocols such as Noise IK, as used in {{Wireguard2020}}, indicate
+its continued real-world usage while quantum-safe authentication methods become
+more available.
+
+Allowing application developers to deploy quantum-resistent encryption as
 a transitional measure without deprecating the classical authentication properties of
-their application provides a path towards quantum readiness.
+their application provides a path towards quantum readiness, similar in concept to
+{{?RFC8773}} and {{?RFC9257}}, where the introduction of a quantum-resistent PSK as a
+transitional measure is also discussed.
 
 # Security Considerations {#sec-security}
 

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -32,6 +32,11 @@ author:
     role: editor
     organization: Freedom of the Press Foundation
     email: ro@freedom.press
+  - fullname: Giulio Berra
+    role: editor
+    organization: Freedom of the Press Foundation
+    email: giulio@freedom.press
+
 
 normative:
   I-D.ietf-hpke-hpke:

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -301,7 +301,7 @@ Whether
 this property holds formally for a specific `CombineSecrets` variant depends on
 that variant's security analysis, which is outside the scope of this document.
 
-Authentication remains entirely classical; a quantum adversary that breaks the
+A quantum adversary that breaks the
 DH assumption can also forge sender authentication, so post-quantum sender
 authentication would require an additional PQ signature. Note that {{Alwen2023}}
 describes a related hybrid construction in which a PQ *AKEM* (rather than a
@@ -334,29 +334,37 @@ Simple APIs that allow application developers to deploy quantum-resistent encryp
 a transitional measure without deprecating the classical authentication properties of
 their application provides a path towards quantum readiness.
 
-### AKEM/PQ KEM Combiner (Informative) {sec-combiner}
+### AKEM/PQ KEM "Combiner" (Informative) {sec-combiner}
 
 Using `mode_auth_psk` with the shared secret from a PQ-KEM as the provided "psk"
-value can provide transitional security properties, namely, hybrid PQ/T confidentiality
-and classical authentication, using ready-made libraries and APIs.
+value allows application developers to provide hybrid security properties,
+namely, hybrid PQ/T confidentiality and classical authentication, using ready-made
+libraries and APIs.
 
-Although this is not a pre-shared key in the true sense, the terminology from
+Although not a true pre-shared key, the terminology from
 {{Alwen2023}}, where a similar construction is described, is retained.
+This off-the-shelf implementation of {{!I-D.ounsworth-cfrg-kem-combiners}} uses
+`mode_auth_psk` from {{?RFC9180}}, as found in existing HPKE implementations such as
+tink-crypto (Google), mlsc++ (Cisco), hpke-rs (Cryspen), to allow non-cryptographers
+to construct a KEM combiner without having to manage their own encryption context.
 
-The following terms are used in this section:
+The sender encapsulates a PQ-KEM to the receiver's PQ public key `pkR_pq`, using
+the resulting shared secret `ss_pq` as "PSK", and a static identifier as the
+PSK identifier. The receiver's PQ public key `pkR_pq` is included in `info` to
+bind it to the key schedule.
+
+The shared secret `ss_pq` must satisfy the entropy requirement in
+{{Section 9.5 of !I-D.ietf-hpke-hpke}}.
+
+As with {{sec-hybrid}}, only classical sender authentication is provided.
+
+An example construction is provided below, with reference to the following terms:
 
 - **PQ-KEM:** a post-quantum KEM, e.g., ML-KEM {{FIPS203}} or an
   algorithm from {{?I-D.ietf-hpke-pq}}.
 - `PQKEM.Encap(pkR_pq)`: PQ-KEM encapsulation; returns `(ss_pq, enc_pq)`.
 - `PQKEM.Decap(enc_pq, skR_pq)`: PQ-KEM decapsulation; returns `ss_pq`.
 - `Nenc_pq`: the fixed ciphertext length of the chosen PQ-KEM, in bytes.
-
-The sender encapsulates a PQ-KEM to the receiver's PQ public key `pkR_pq`, using
-the resulting shared secret `ss_pq` as the HPKE PSK and the PQ ciphertext
-`enc_pq` as the PSK identifier. The receiver's PQ public key `pkR_pq` is
-included in `info` to bind it to the key schedule. The combined encapsulation is
-`concat(enc_dh, enc_pq)`; `Nenc` bytes are parsed as `enc_dh` and the remaining
-`Nenc_pq` bytes as `enc_pq`.
 
 ~~~
 def HybridSetupS(pkR, pkR_pq, skS, info):
@@ -377,20 +385,6 @@ generated for each encapsulation; reuse of a prior `enc_pq` is prohibited. The
 `(KEM_ID, KDF_ID, AEAD_ID)`; the PQ-KEM algorithm identity should be conveyed
 via application-layer framing or the `info` parameter when multiple PQ-KEM
 algorithms are supported.
-
-This is a cheap implementation of a construction similar to
-{{!I-D.ounsworth-cfrg-kem-combiners}}. The ML-KEM shared secret `ss_pq` satisfies the
-entropy requirement in {{Section 9.5 of !I-D.ietf-hpke-hpke}} (32 bytes of
-uniform randomness).
-
-Authentication remains entirely classical; a quantum adversary that breaks the
-DH assumption can also forge sender authentication, so post-quantum sender
-authentication would require an additional PQ signature. Note that {{Alwen2023}}
-describes a related hybrid construction in which a PQ *AKEM* (rather than a
-plain KEM) is used to generate the PSK, which would additionally provide
-post-quantum sender authentication; that stronger construction is outside the
-scope of this document.
-
 
 # Security Considerations {#sec-security}
 

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -74,6 +74,18 @@ informative:
     rc: "Advances in Cryptology -- ASIACRYPT 2023"
     target: https://eprint.iacr.org/2023/1480
   I-D.draft-connolly-cfrg-xwing-kem-10:
+  PQCodePkgs:
+    title: "PQ Code Package Repositories (accessed 2026-04-30)"
+    author:
+      org: "Post Quantum Cryptography Alliance"
+    date: 2026
+    target: https://github.com/orgs/pq-code-package/repositories
+  Wireguard2020:
+    title: "WireGuard: Next Generation Kernel Network Tunnel"
+    author:
+      - name: Jason A. Donenfeld
+    date: 2020
+    target: https://www.wireguard.com/papers/wireguard.pdf
 
 --- abstract
 
@@ -320,44 +332,25 @@ A quantum adversary with access to the PSK can also forge authenticated messages
 entropy requirement in {{Section 9.5 of !I-D.ietf-hpke-hpke}} (32 bytes of
 uniform randomness).
 
-## Discussion {#sec-discussion}
-
-Downstream application developers are in a bind: though they may be aware of advice to
-implement quantum-safe encryption on an accelerated timeline, they may encounter rapidly-
-evolving guidance on best practices, a lack of direct parity with classical constructions,
-and a releative paucity of stable APIs suitable for non-cryptographers.
-
-Non-cryptographers looking to offer classical/quantum-safe (hybrid) encryption in their
-own applications can refer to {{?I-D.draft-connolly-cfrg-xwing-kem-10}}, although existing
-implementations are at an early stage of development; or may refer to the now-expired
-{{!I-D.ounsworth-cfrg-kem-combiners}}, but will need to manage their own encryption context.
-
-Further, the guidance on post-quantum signature schemes is still under active development,
-and if libraries are available, they come with strong caveats about changing APIs and general
-maturity.
-
-Although DH-based classical authentication is not future-forward, it remains in use.
-Simple APIs that allow application developers to deploy quantum-resistent encryption as
-a transitional measure without deprecating the classical authentication properties of
-their application provides a path towards quantum readiness.
-
-### AKEM/PQ KEM "Combiner" (Informative) {sec-combiner}
+### AKEM/PQ KEM "Combiner" (Informative) {#sec-combiner}
 
 Using `mode_auth_psk` with the shared secret from a PQ-KEM as the provided "psk"
-value allows application developers to provide hybrid security properties,
-namely, hybrid PQ/T confidentiality and classical authentication, using ready-made
-libraries and APIs.
+value allows application developers to provide hybrid-transitional security properties
+using ready-made libraries and APIs. Although not a true pre-shared key, the terminology
+from similar work by {{Alwen2023}} ("pskAPKE") is retained.
 
-Although not a true pre-shared key, the terminology from
-{{Alwen2023}}, where a similar construction is described, is retained.
-This off-the-shelf implementation of {{!I-D.ounsworth-cfrg-kem-combiners}} uses
-`mode_auth_psk` from {{?RFC9180}}, as found in existing HPKE implementations such as
-tink-crypto (Google), mlsc++ (Cisco), hpke-rs (Cryspen), to allow non-cryptographers
-to construct a KEM combiner without having to manage their own encryption context.
+The result is a KEM combiner-style construction {{!I-D.ounsworth-cfrg-kem-combiners}}
+that provides hybrid PQ/T confidentiality and classical authentication, without requiring
+developers to manage their own encryption context, a frequent source of developer error
+and a motivating factor for the API design choices of {{?RFC9180}}.
 
-The sender encapsulates a PQ-KEM to the receiver's PQ public key `pkR_pq`, using
-the resulting shared secret `ss_pq` as "PSK", and a static identifier as the
-PSK identifier. The receiver's PQ public key `pkR_pq` is included in `info` to
+In addition to the keypair specified in {{sec-setup}}, the receiver holds an additional
+post-quantim keypair, (`skR_pq`, `pkR_pq`).
+Prior to setting up an HPKE encryption context (either via `Setup` or via a single-shot
+API), the sender encapsulates a PQ-KEM to the receiver's PQ public key `pkR_pq`, using
+the resulting shared secret `ss_pq` as a "PSK", and a static identifier as the PSK
+identifier.
+The ciphertext encapsulation of `ss_pq`, `enc_pq`, is included in `info` to
 bind it to the key schedule.
 
 An example construction is provided below, with reference to the following terms:
@@ -380,13 +373,52 @@ def HybridSetupR(enc, skR, skR_pq, pkR_pq, pkS, info):
   return SetupAuthPSKR(enc_dh, skR, concat(info, enc_pq), ss_pq, enc_pq, pkS)
 ~~~
 
+**Classical (implicit) sender authentication:** Only classical sender
+authentication is provided; in contrast to {{sec-hybrid}}, the "psk" value
+provides no sender authentication, as it is constructed rather than pre-shared.
+This limitation is assessed in {{sec-motivation}}.
+
+The `info` parameter will exceed 64 bytes. Implementors must ensure their choice of
+algorithms and underlying implementation can support parameters of this length.
+
+The shared secret `ss_pq` must satisfy the entropy requirement in
+{{Section 9.5 of !I-D.ietf-hpke-hpke}}.
+
 Implementations should verify `len(enc) == Nenc + Nenc_pq` and reject
 encapsulations of any other length. A fresh `(ss_pq, enc_pq)` pair should be
 generated for each encapsulation; reuse of a prior `enc_pq` is prohibited. The
-`suite_id` in the HPKE key schedule reflects only the classical ciphersuite
-`(KEM_ID, KDF_ID, AEAD_ID)`; the PQ-KEM algorithm identity should be conveyed
-via application-layer framing or the `info` parameter when multiple PQ-KEM
-algorithms are supported.
+`suite_id` in the HPKE key schedule reflects only the ciphersuite
+`(AKEM_ID, KDF_ID, AEAD_ID)`; the PQ-KEM algorithm identity should be conveyed
+via application-layer framing when multiple PQ-KEM algorithms are supported.
+
+Note that {{Alwen2023}}
+describes a related hybrid construction in which a PQ *AKEM* (rather than a
+plain KEM) is used to generate the PSK, which would additionally provide
+post-quantum sender authentication; that stronger construction is outside the
+scope of this document.
+
+## Motivation (Informative) {#sec-motivation}
+
+Downstream application developers are in a bind: though they may be aware of advice to
+implement quantum-safe encryption on an accelerated timeline, they may encounter rapidly-
+evolving guidance on best practices, a lack of direct parity with classical constructions,
+and a releative paucity of stable APIs suitable for non-cryptographers {{PQCodePkgs}}.
+
+Non-cryptographers looking to offer classical/quantum-safe (hybrid) encryption in their
+own applications can look to early-stage implementations of
+{{?I-D.draft-connolly-cfrg-xwing-kem-10}}, or may refer to now-expired
+{{!I-D.ounsworth-cfrg-kem-combiners}}, but will need to manage their own implementation.
+Further, the guidance on post-quantum signature schemes is still under active development,
+and if libraries are available, they come with strong caveats about changing APIs and general
+maturity.
+
+Although DH-based authentication is not future-forward, it remains in widespread use.
+Further, although the property of hybrid encryption with classical authentication is not as
+straightforward to communicate as an unauthenticated hybrid construct, protocols such as
+Noise IK, as used in {{Wireguard2020}}, indicate their usage.
+Simple APIs that allow application developers to deploy quantum-resistent encryption as
+a transitional measure without deprecating the classical authentication properties of
+their application provides a path towards quantum readiness.
 
 # Security Considerations {#sec-security}
 

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -27,7 +27,7 @@ author:
     role: editor
     organization: Freedom of the Press Foundation
     email: cfm@acm.org
-  - fullname: Rowen S.
+  - fullname: Rowen Shane
     role: editor
     organization: Freedom of the Press Foundation
     email: ro@freedom.press

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -391,31 +391,6 @@ plain KEM) is used to generate the PSK, which would additionally provide
 post-quantum sender authentication; that stronger construction is outside the
 scope of this document.
 
-**PSK freshness.** The ML-KEM shared secret `ss_pq` satisfies the
-entropy requirement in {{Section 9.5 of !I-D.ietf-hpke-hpke}} (32 bytes of
-uniform randomness). The prohibition on `enc_pq` reuse above ensures a fresh PSK
-per session.
-
-# HPKE-Auth Profiles (Informative) {#sec-suites}
-
-This section is informative. The profiles below are suggested KEM and KDF
-parameter sets for the example applications in {{sec-dh-akem}}; they are not
-registered by this document. Because `AEAD_ID` is selected by the application,
-these are parameter sets, not fully determined ciphersuites. `KEM_ID` and
-`KDF_ID` are drawn from the registries in {{I-D.ietf-hpke-hpke}}.
-
-| Profile                                    | `KEM_ID` | `KDF_ID` | `PQKEM`     | `Nenc` | `Nenc_pq` |
-| ------------------------------------------ | -------- | -------- | ----------- | ----- | ---------- |
-| `HPKE-Auth-X25519-SHA256`                  | `0x0020` | `0x0001` | ---         | 32    | ---        |
-| `HPKE-Auth-P256-SHA256`                    | `0x0010` | `0x0001` | ---         | 65    | ---        |
-| `HPKE-Auth-X448-SHA512`                    | `0x0021` | `0x0003` | ---         | 56    | ---        |
-| `HPKE-Auth-Hybrid-X25519-SHA256-MLKEM768`  | `0x0020` | `0x0001` | ML-KEM-768  | 32    | 1088       |
-| `HPKE-Auth-Hybrid-X25519-SHA256-MLKEM1024` | `0x0020` | `0x0001` | ML-KEM-1024 | 32    | 1568       |
-| `HPKE-Auth-Hybrid-P256-SHA256-MLKEM768`    | `0x0010` | `0x0001` | ML-KEM-768  | 65    | 1088       |
-
-ML-KEM parameters are from {{FIPS203}}.
-`HPKE-Auth-Hybrid-X25519-SHA256-MLKEM768` is the suggested default hybrid
-profile, yielding a combined encapsulation of 1120 bytes.
 
 # Security Considerations {#sec-security}
 

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -83,7 +83,7 @@ This document restores `mode_auth_psk` mode as a strict extension, and illustrat
 how the restored mode can be used with a post-quantum shared secret as the PSK
 by application developers seeking to achieve hybrid PQ/T confidentiality while
 transitioning to quantum-safe encryption, without deprecating the implicit
-authentication properties of DH-AKEM on which many applications still rely.
+authentication properties of DHAKEM on which many applications still rely.
 
 This extension requires only the
 addition of `AuthEncap()`/`AuthDecap()` to the DHKEM, the definition of four
@@ -95,10 +95,11 @@ the mode itself is not restored due to its inability to provide quantum safety.
 
 The transitional nature of the AuthPSK construction and its security properties
 are discussed.
-This document also illustrates how the restored mode can be used to provide
-ready-made KEM combiner-like functionality ({{!I-D.ounsworth-cfrg-kem-combiners}}).
-It provides examples for the usage of such a construction as a transitional
-step towards quantum readiness to motivate the extension.
+Finally, the document illustrates how the restored mode can be used to provide
+ready-made KEM combiner-like functionality ({{!I-D.ounsworth-cfrg-kem-combiners}})
+without requiring downstream API users to manage their own encryption context.
+The use of this construction as a transitional step towards quantum readiness
+motivates this extension.
 
 --- middle
 
@@ -107,34 +108,34 @@ step towards quantum readiness to motivate the extension.
 {{!I-D.ietf-hpke-hpke}} is the standards-track successor to the informational
 {{?RFC9180}} and omits the authenticated modes `mode_auth` and `mode_auth_psk`
 to simplify the standard.
-However, some applications make use of the implicit sender authentication those
-modes provide.
-The DHKEM construction in {{?RFC9180}} already contains all the primitives needed:
+However, some applications make use of the type of implicit sender authentication
+those modes provide.
+
+The normative portion of this document is small.  It restores
+`mode_auth_psk` as a strict extension to {{!I-D.ietf-hpke-hpke}}.
+This requires `AuthEncap()`/`AuthDecap()` from the DHKEM construction in
+{{?RFC9180}}, and a modified `VerifyPSKInputs()`. The externally observable
+behavior of existing HPKE modes is unchanged.
 `AuthEncap()` computes a static-static DH value `DH(skS, pkR)` alongside the
 ephemeral-static value and mixes both into the key derivation, binding the
 output to the sender's key pair.
 
-The normative portion of this document is small.  It restores
-`mode_auth_psk` as a strict extension to {{!I-D.ietf-hpke-hpke}}, requiring only
-`AuthEncap()`/`AuthDecap()` on the DHKEM, four setup functions, and a modified
-`VerifyPSKInputs()`. The externally observable behavior of existing HPKE modes
-is unchanged.
-Although `AuthEncap()`/`AuthDecap()` reintroduce the functionality of `mode_auth`,
-the mode, which relies solely on a DHKEM construction, is not restored due to its
-inability to provide quantum-safe encryption.
-Instead, it is instead treated as a building block to `mode_auth_psk`, as seen in
-{{sec-dh-akem}}.
+Although the functionality of `mode_auth` is re-introduced, the mode identifer
+itself, which relies solely on DHKEM, is not restored due to its inability to
+provide quantum-safe encryption. Instead, it is instead treated as a building
+block to `mode_auth_psk`, as seen in {{sec-dhakem}}.
 
 {{sec-authencap}} describes how the restored
 mode can be used to achieve hybrid PQ/T confidentiality as
 defined in {{Section 5 of ?RFC9794}} during the transition to quantum-safe encryption.
-{{sec-discussion}} discusses the transitional nature of this construction and reviews
+{{sec-motivation}} discusses the transitional nature of this construction and reviews
 the guidance available to application developers looking to begin the transition to
 quantum-safe encryption with existing libraries and APIs.
 
-{{sec-use-cases}} discusses how the extension can be used as a type of black-box KEM combiner
-({{!I-D.ounsworth-cfrg-kem-combiners}}), with reference to {{Alwen2023}}.
-Example use cases are provided to motivate the extension.
+To motivate the extension, {{sec-combiner}} discusses how the extension can be used
+as a type of black-box KEM combiner ({{!I-D.ounsworth-cfrg-kem-combiners}}), similar to
+the construction proposed in {{Alwen2023}}, to allow application developers to begin
+the transition to quantum-safe encryption via usable libraries and APIs.
 
 # Conventions and Definitions
 {::boilerplate bcp14-tagged}
@@ -174,7 +175,8 @@ and its identifier is therefore not reintroduced.
 
 ## DHKEM Extension: `AuthEncap()` and `AuthDecap()` {#sec-authencap}
 
-The following two functions are added to the DHKEM, extending it to an AKEM.
+The following two functions are added to the DHKEM, extending it to an AKEM
+(DHAKEM).
 They are reproduced verbatim from {{Section 4.1 of ?RFC9180}}. All helper
 functions (`GenerateKeyPair`, `DH`, `SerializePublicKey`,
 `DeserializePublicKey`, `ExtractAndExpand`) are as defined in
@@ -209,7 +211,8 @@ def AuthDecap(enc, skR, pkS):
 Note that the `AuthEncap()` and `AuthDecap()` functions are vulnerable to
 key-compromise impersonation (KCI): the assurance that the shared secret was
 generated by the holder of the private key `skS` does not hold if the recipient
-private key `skR` is compromised. See {{sec-security}} for further discussion.
+private key `skR` is compromised. See {{sec-security}} for further discussion;
+see {{sec-setup}} for integration of a pre-shared key.
 
 ## `VerifyPSKInputs`
 
@@ -224,15 +227,14 @@ def VerifyPSKInputs(mode, psk, psk_id):
   if got_psk != got_psk_id:
     raise Exception("Inconsistent PSK inputs")
 
-  if got_psk and mode in [mode_base, mode_auth]:
+  if got_psk and mode in [mode_base]:
     raise Exception("PSK input provided when not needed")
   if (not got_psk) and mode in [mode_psk, mode_auth_psk]:
     raise Exception("Missing required PSK input")
 ~~~
 
-The only change from the original is that `mode_base` is replaced by
-`[mode_base, mode_auth]` and `mode_psk` is replaced by `[mode_psk,
-mode_auth_psk]` in the final two guards.
+The only change from the original is that `mode_psk` is replaced by
+`[mode_psk, mode_auth_psk]` in the final guard.
 
 ## Setup Functions {#sec-setup}
 
@@ -260,7 +262,7 @@ In addition to the validation requirements in {{Section 7.1.4 of
 key `pkS` before use in `AuthDecap()`, applying the same validation rules as for
 other public key inputs. Validation failure MUST yield a `ValidationError`.
 
-# DH-AKEM with PSK {#sec-dh-akem}
+## DHAKEM with PSK {#sec-dhakem}
 
 This section illustrates how the authenticated mode defined
 in {{sec-ext}} can be used.  Any AEAD identifier from {{I-D.ietf-hpke-hpke}} may
@@ -269,12 +271,14 @@ Key generation follows `GenerateKeyPair()` from {{I-D.ietf-hpke-hpke}}.
 
 `mode_auth_psk` may be used via its setup function: the sender calls
 `SetupAuthPSKS()` and the receiver calls `SetupAuthPSKR()`, with a pre-shared key
-and PSK identifier, as defined in {{sec-setup}}.
+`psk` and a PSK identifier `psk_id`, as defined in {{sec-setup}}.
+As in {{?RFC9180}}, both parties are assumped to have been provisioned with the
+PSK value `psk` and another byte string `psk_id`.
 
-This mode SHOULD be used with a quantum-safe PSK as described below in
+This mode SHOULD be used with a quantum-safe PSK value as described below in
 order to offer hybrid confidentiality properties.
 
-## PQ/T Hybrid Construction {#sec-hybrid}
+### PQ/T Hybrid Construction {#sec-hybrid}
 
 ~~~
 def HybridSetupS(pkR, skS, info, psk, psk_id):
@@ -285,8 +289,10 @@ def HybridSetupR(enc, skR, pkS, info, psk, psk):
   return SetupAuthPSKR(enc_dh, skR, info, psk, psk_id, pkS)
 ~~~
 
-The `suite_id` in the HPKE key schedule reflects only the classical ciphersuite
-`(KEM_ID, KDF_ID, AEAD_ID)`.
+The `suite_id` in the HPKE key schedule reflects only the ciphersuite
+`(KEM_ID, KDF_ID, AEAD_ID)`, where `KEM_ID` is a DHAKEM.
+Generation and distribution of a quantum-safe PSK value is left to the
+application.
 
 **Hybrid confidentiality.** `KeyScheduleS()`/`KeyScheduleR()` delegate to
 `CombineSecrets`, for which {{!I-D.ietf-hpke-hpke}} defines two variants. In

--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -16,6 +16,7 @@ keyword:
   - authenticated KEM
   - DHKEM
   - HPKE
+  - KEM combiner
 venue:
 #  group: HPKE
 #  type: Working Group
@@ -67,21 +68,32 @@ informative:
     date: 2023
     rc: "Advances in Cryptology -- ASIACRYPT 2023"
     target: https://eprint.iacr.org/2023/1480
+  I-D.draft-connolly-cfrg-xwing-kem-10:
 
 --- abstract
 
 The standards-track {{!I-D.ietf-hpke-hpke}} supersedes the informational
 {{?RFC9180}}, omitting its authenticated modes `mode_auth` and `mode_auth_psk`.
-This document restores those two modes as a strict extension, requiring only the
+This document restores `mode_auth_psk` mode as a strict extension, and illustrates
+how the restored mode can be used with a post-quantum shared secret as the PSK
+by application developers seeking to achieve hybrid PQ/T confidentiality while
+transitioning to quantum-safe encryption, without deprecating the implicit
+authentication properties of DH-AKEM on which many applications still rely.
+
+This extension requires only the
 addition of `AuthEncap()`/`AuthDecap()` to the DHKEM, the definition of four
 setup functions, and a change in `VerifyPSKInputs()`.  The extension does not
 alter the externally observable behavior of the existing HPKE modes standardized
 in {{!I-D.ietf-hpke-hpke}}.
+Although `AuthEncap()`/`AuthDecap()` reintroduce the functionality of `mode_auth`,
+the mode itself is not restored due to its inability to provide quantum safety.
 
-This document also illustrates, informatively, how the restored modes can be
-used. One such application uses `mode_auth_psk` with a post-quantum KEM (PQ-KEM)
-shared secret as the PSK, providing hybrid PQ/T confidentiality. This material
-is provided to motivate the extension and may be developed as separate work.
+The transitional nature of the AuthPSK construction and its security properties
+are discussed.
+This document also illustrates how the restored mode can be used to provide
+ready-made KEM combiner-like functionality ({{!I-D.ounsworth-cfrg-kem-combiners}}).
+It provides examples for the usage of such a construction as a transitional
+step towards quantum readiness to motivate the extension.
 
 --- middle
 
@@ -89,54 +101,71 @@ is provided to motivate the extension and may be developed as separate work.
 
 {{!I-D.ietf-hpke-hpke}} is the standards-track successor to the informational
 {{?RFC9180}} and omits the authenticated modes `mode_auth` and `mode_auth_psk`
-to simplify the standard. However, some protocols require an authenticated
-key-encapsulation mechanism (AKEM)---a KEM whose shared secret is implicitly
-bound to the sender's static private key---without requiring a full
-authenticated encryption context.  The DHKEM construction in
-{{!I-D.ietf-hpke-hpke}} already contains all the primitives needed:
+to simplify the standard.
+However, some applications make use of the implicit sender authentication those
+modes provide.
+The DHKEM construction in {{?RFC9180}} already contains all the primitives needed:
 `AuthEncap()` computes a static-static DH value `DH(skS, pkR)` alongside the
 ephemeral-static value and mixes both into the key derivation, binding the
 output to the sender's key pair.
 
-The normative portion of this document is small.  It restores `mode_auth` and
+The normative portion of this document is small.  It restores
 `mode_auth_psk` as a strict extension to {{!I-D.ietf-hpke-hpke}}, requiring only
 `AuthEncap()`/`AuthDecap()` on the DHKEM, four setup functions, and a modified
 `VerifyPSKInputs()`. The externally observable behavior of existing HPKE modes
 is unchanged.
+Although `AuthEncap()`/`AuthDecap()` reintroduce the functionality of `mode_auth`,
+the mode, which relies solely on a DHKEM construction, is not restored due to its
+inability to provide quantum-safe encryption.
+Instead, it is instead treated as a building block to `mode_auth_psk`, as seen in
+{{sec-dh-akem}}.
 
-{{sec-dh-akem}} and {{sec-suites}} describe, informatively, how the restored
-modes can be used, including a construction that layers a post-quantum KEM
-shared secret as the PSK to achieve hybrid PQ/T confidentiality as defined in
-{{Section 5 of ?RFC9794}}. That material is provided to motivate the extension
-and may be developed as separate work.
+{{sec-authencap}} describes how the restored
+mode can be used to achieve hybrid PQ/T confidentiality as
+defined in {{Section 5 of ?RFC9794}} during the transition to quantum-safe encryption.
+{{sec-discussion}} discusses the transitional nature of this construction and reviews
+the guidance available to application developers looking to begin the transition to
+quantum-safe encryption with existing libraries and APIs.
+
+{{sec-use-cases}} discusses how the extension can be used as a type of black-box KEM combiner
+({{!I-D.ounsworth-cfrg-kem-combiners}}), with reference to {{Alwen2023}}.
+Example use cases are provided to motivate the extension.
 
 # Conventions and Definitions
 {::boilerplate bcp14-tagged}
 
-Terms from {{I-D.ietf-hpke-hpke}} are used without redefinition. The following
-additional term is used herein:
+Terms from {{I-D.ietf-hpke-hpke}} are used without redefinition; particular reference is
+made to the **DHKEM** construction {{Section 4.1 of ?RFC9180}}.
+The following additional term is used herein:
 
 - **AKEM:** a KEM whose encapsulation additionally takes the sender's static
   private key and implicitly binds the shared secret to it.
 
-# Authenticated Mode Extensions to {{I-D.ietf-hpke-hpke}} {#sec-ext}
+# Authenticated Pre-Shared Key Mode Extension to {{I-D.ietf-hpke-hpke}} {#sec-ext}
 
 This section specifies the additions to {{!I-D.ietf-hpke-hpke}} required to
-restore `mode_auth` and `mode_auth_psk`. These extensions are defined so that
+restore `mode_auth_psk`. These extensions are defined so that
 the externally observable behavior of the existing HPKE modes is unchanged,
 although this document modifies the `VerifyPSKInputs()` procedure in
 {{I-D.ietf-hpke-hpke}}.
 
 ## Mode Identifiers
 
-The reserved entries for values `0x02` and `0x03` in Table 1 of
-{{!I-D.ietf-hpke-hpke}} are replaced with the following mode identifiers, as
+The reserved entry for value `0x03` in Table 1 of
+{{!I-D.ietf-hpke-hpke}} is replaced with the following mode identifier, as
 originally specified in Table 1 of {{?RFC9180}}:
 
 ~~~
-mode_auth     = 0x02
 mode_auth_psk = 0x03
 ~~~
+
+The value `0x02` remains reserved.
+
+## Exclusion of 0x02 `mode_auth` from Mode Identifiers
+
+Although restoring  the `AuthEncap()` and `AuthDecap()` functions would also
+allow for restoring `mode_auth`, this mode cannot offer quantum-safe encryption,
+and its identifier is therefore not reintroduced.
 
 ## DHKEM Extension: `AuthEncap()` and `AuthDecap()` {#sec-authencap}
 
@@ -208,16 +237,6 @@ and 5.1.4 of ?RFC9180}}.  `KeyScheduleS()`/`KeyScheduleR()` and
 {{sec-authencap}} respectively.
 
 ~~~
-def SetupAuthS(pkR, info, skS):
-  shared_secret, enc = AuthEncap(pkR, skS)
-  return enc, KeyScheduleS(mode_auth, shared_secret, info,
-                           default_psk, default_psk_id)
-
-def SetupAuthR(enc, skR, info, pkS):
-  shared_secret = AuthDecap(enc, skR, pkS)
-  return KeyScheduleR(mode_auth, shared_secret, info,
-                      default_psk, default_psk_id)
-
 def SetupAuthPSKS(pkR, info, psk, psk_id, skS):
   shared_secret, enc = AuthEncap(pkR, skS)
   return enc, KeyScheduleS(mode_auth_psk, shared_secret, info,
@@ -236,20 +255,93 @@ In addition to the validation requirements in {{Section 7.1.4 of
 key `pkS` before use in `AuthDecap()`, applying the same validation rules as for
 other public key inputs. Validation failure MUST yield a `ValidationError`.
 
-# Example Applications (Informative) {#sec-dh-akem}
+# DH-AKEM with PSK {#sec-dh-akem}
 
-This section is informative. It illustrates how the authenticated modes defined
+This section illustrates how the authenticated mode defined
 in {{sec-ext}} can be used.  Any AEAD identifier from {{I-D.ietf-hpke-hpke}} may
 be used; the resulting context supports `Seal()`, `Open()`, and `Export()`.
 Key generation follows `GenerateKeyPair()` from {{I-D.ietf-hpke-hpke}}.
 
-The modes may be used directly via their setup functions.  For `mode_auth`, the
-sender calls `SetupAuthS(pkR, info, skS)` and the receiver calls
-`SetupAuthR(enc, skR, info, pkS)`.  For `mode_auth_psk`, the sender calls
-`SetupAuthPSKS()` and the receiver calls `SetupAuthPSKR()`, with a shared PSK
+`mode_auth_psk` may be used via its setup function: the sender calls
+`SetupAuthPSKS()` and the receiver calls `SetupAuthPSKR()`, with a pre-shared key
 and PSK identifier, as defined in {{sec-setup}}.
 
-## Hybrid PQ/T Profile (`mode_auth_psk` with PQ-KEM PSK) {#sec-hybrid}
+This mode SHOULD be used with a quantum-safe PSK as described below in
+order to offer hybrid confidentiality properties.
+
+## PQ/T Hybrid Construction {#sec-hybrid}
+
+~~~
+def HybridSetupS(pkR, skS, info, psk, psk_id):
+  enc_dh, ctx = SetupAuthPSKS(pkR, info, psk, psk_id, skS)
+  return enc_dh, ctx
+
+def HybridSetupR(enc, skR, pkS, info, psk, psk):
+  return SetupAuthPSKR(enc_dh, skR, info, psk, psk_id, pkS)
+~~~
+
+The `suite_id` in the HPKE key schedule reflects only the classical ciphersuite
+`(KEM_ID, KDF_ID, AEAD_ID)`.
+
+**Hybrid confidentiality.** `KeyScheduleS()`/`KeyScheduleR()` delegate to
+`CombineSecrets`, for which {{!I-D.ietf-hpke-hpke}} defines two variants. In
+`CombineSecrets_TwoStage()`, the combination is `secret =
+LabeledExtract(dhkem_shared_secret, "secret", psk)`, equivalent to
+`HKDF-Extract(salt = dhkem_shared_secret, IKM = psk)` {{?RFC5869}}. In
+`CombineSecrets_OneStage()`, `dhkem_shared_secret` and `psk` are length-prefixed
+and concatenated before a single `LabeledDerive()` call. In both cases,
+`dhkem_shared_secret` and `psk` enter the combination as independent inputs.
+The intended design property is that `secret` remains pseudorandom as long as at
+least one of the two inputs is---meaning an adversary would need to attack both
+the classical DH-based component and the PQ-KEM to recover `secret`, as seen
+in {{!I-D.ounsworth-cfrg-kem-combiners}} and subsequently,
+{{?I-D.draft-connolly-cfrg-xwing-kem-10}}.
+
+Whether
+this property holds formally for a specific `CombineSecrets` variant depends on
+that variant's security analysis, which is outside the scope of this document.
+
+Authentication remains entirely classical; a quantum adversary that breaks the
+DH assumption can also forge sender authentication, so post-quantum sender
+authentication would require an additional PQ signature. Note that {{Alwen2023}}
+describes a related hybrid construction in which a PQ *AKEM* (rather than a
+plain KEM) is used to generate the PSK, which would additionally provide
+post-quantum sender authentication; that stronger construction is outside the
+scope of this document.
+
+**PSK freshness.** The PSK `psk` MUST satisfy the
+entropy requirement in {{Section 9.5 of !I-D.ietf-hpke-hpke}} (32 bytes of
+uniform randomness).
+
+## Discussion {#sec-discussion}
+
+Downstream application developers are in a bind: though they may be aware of advice to
+implement quantum-safe encryption on an accelerated timeline, they may encounter rapidly-
+evolving guidance on best practices, a lack of direct parity with classical constructions,
+and a releative paucity of stable APIs suitable for non-cryptographers.
+
+Non-cryptographers looking to offer classical/quantum-safe (hybrid) encryption in their
+own applications can refer to {{?I-D.draft-connolly-cfrg-xwing-kem-10}}, although existing
+implementations are at an early stage of development; or may refer to the now-expired
+{{!I-D.ounsworth-cfrg-kem-combiners}}, but will need to manage their own encryption context.
+
+Further, the guidance on post-quantum signature schemes is still under active development,
+and if libraries are available, they come with strong caveats about changing APIs and general
+maturity.
+
+Although DH-based classical authentication is not future-forward, it remains in use.
+Simple APIs that allow application developers to deploy quantum-resistent encryption as
+a transitional measure without deprecating the classical authentication properties of
+their application provides a path towards quantum readiness.
+
+### AKEM/PQ KEM Combiner (Informative) {sec-combiner}
+
+Using `mode_auth_psk` with the shared secret from a PQ-KEM as the provided "psk"
+value can provide transitional security properties, namely, hybrid PQ/T confidentiality
+and classical authentication, using ready-made libraries and APIs.
+
+Although this is not a pre-shared key in the true sense, the terminology from
+{{Alwen2023}}, where a similar construction is described, is retained.
 
 The following terms are used in this section:
 
@@ -286,19 +378,11 @@ generated for each encapsulation; reuse of a prior `enc_pq` is prohibited. The
 via application-layer framing or the `info` parameter when multiple PQ-KEM
 algorithms are supported.
 
-**Hybrid confidentiality.** `KeyScheduleS()`/`KeyScheduleR()` delegate to
-`CombineSecrets`, for which {{!I-D.ietf-hpke-hpke}} defines two variants. In
-`CombineSecrets_TwoStage()`, the combination is `secret =
-LabeledExtract(dhkem_shared_secret, "secret", psk)`, equivalent to
-`HKDF-Extract(salt = dhkem_shared_secret, IKM = ss_pq)` {{?RFC5869}}. In
-`CombineSecrets_OneStage()`, `dhkem_shared_secret` and `psk` are length-prefixed
-and concatenated before a single `LabeledDerive()` call. In both cases,
-`dhkem_shared_secret` and `ss_pq` enter the combination as independent inputs.
-The intended design property is that `secret` remains pseudorandom as long as at
-least one of the two inputs is---meaning an adversary would need to attack both
-the classical DH-based component and the PQ-KEM to recover `secret`.  Whether
-this property holds formally for a specific `CombineSecrets` variant depends on
-that variant's security analysis, which is outside the scope of this document.
+This is a cheap implementation of a construction similar to
+{{!I-D.ounsworth-cfrg-kem-combiners}}. The ML-KEM shared secret `ss_pq` satisfies the
+entropy requirement in {{Section 9.5 of !I-D.ietf-hpke-hpke}} (32 bytes of
+uniform randomness).
+
 Authentication remains entirely classical; a quantum adversary that breaks the
 DH assumption can also forge sender authentication, so post-quantum sender
 authentication would require an additional PQ signature. Note that {{Alwen2023}}
@@ -336,7 +420,7 @@ profile, yielding a combined encapsulation of 1120 bytes.
 # Security Considerations {#sec-security}
 
 The sender-authentication and key-compromise impersonation (KCI) properties of
-`mode_auth` and `mode_auth_psk` are as described in {{Sections 9.1 and 9.1.1 of
+`mode_auth_psk` are as described in {{Sections 9.1 and 9.1.1 of
 ?RFC9180}}, which apply without change to the functions defined in {{sec-ext}}.
 Security properties specific to the hybrid PQ/T construction are discussed
 informatively in {{sec-hybrid}}.


### PR DESCRIPTION

- Drop `mode_auth` with explanation that it cannot be constructed with quantum safety; treat it like building block to auth_psk
- Treat `mode_auth_psk` with a "true" PSK/pq shared secret, as the focus of the extension
  - Informatively offer `pskAPKE`, but drop the algorithms/parameters since it's just an example; include authentication caveats
  - Drop `mode_auth` references, treat identifier as reserved
- Add Motivation section describing the use-case, and add references to related work mentioning PSK for quantum-safe transition
- Fixup a few small issues (info param composition, adjust param ordering)
- Add @lsd-cat as an author

