### PR TITLE
The editor role isn't needed here

### DIFF
--- a/draft-ms-hpke-auth-modes.md
+++ b/draft-ms-hpke-auth-modes.md
@@ -25,15 +25,12 @@ venue:
 
 author:
   - fullname: Giulio Berra
-    role: editor
     organization: Freedom of the Press Foundation
     email: giulio@freedom.press
   - fullname: Cory Francis Myers
-    role: editor
     organization: Freedom of the Press Foundation
     email: cfm@acm.org
   - fullname: Rowen Shane
-    role: editor
     organization: Freedom of the Press Foundation
     email: ro@freedom.press
 


### PR DESCRIPTION
This is generally reserved for cases where the identified individual is responsible for collating the work of multiple contributors.  You own this work, so own it.